### PR TITLE
FIx failing back-pressure test

### DIFF
--- a/tests/backpressure_test/src/main.xc
+++ b/tests/backpressure_test/src/main.xc
@@ -125,6 +125,8 @@ void test_lr_period(void){
           if (diff > (period + JITTER)) {
               debug_printf("Backpressure breaks at receive delay ticks=%d, send delay ticks=%d\n",
                 *p_receive_delay, *p_send_delay);
+              debug_printf("actual diff: %d, maximum (period + Jitter): %d\n",
+                diff, (period + JITTER));
               _Exit(1);
           }
           time_old = time;


### PR DESCRIPTION
https://github.com/xmos/lib_i2s/issues/28