### PR TITLE
Remove macOS requirement

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ getApproval()
 
 pipeline {
   agent {
-    label 'x86_64&&brew&&macOS'
+    label 'x86_64&&brew'
   }
   environment {
     REPO = 'lib_i2s'


### PR DESCRIPTION
Currently fails when run on Linux:

```
xdoc xmospdf
Building documentation target 'xmospdf' in rst
    Copying ../../api
    Copying ../../../examples/app_simple_i2s_master/src
    Copying ../../../examples/app_simple_i2s_frame_master/src
    Copying ../../../examples/app_simple_i2s_slave/src
    Copying ../../../examples/app_simple_i2s_frame_slave/src
    Copying ../../../examples/app_simple_tdm_master/src
    Found document info for 'I2S Library'
    Processing TOC for XMOS xref database
    Running Doxygen
    Creating resource usage information
    Using headers: ['i2s.h']
    Extracting type information..
    ERROR: Could not build dummy app to extract resource info.
    ERROR: 
Checking build modules
Using build modules: lib_i2s(3.0.1) lib_xassert(3.0.1) lib_logging(2.1.1)

    ERROR: 
bash: /jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/xdoc/xdoc/libtinfo.so.5: no version information available (required by bash)
bash: /jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/xdoc/xdoc/libtinfo.so.5: no version information available (required by bash)
bash: /jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/xdoc/xdoc/libtinfo.so.5: no version information available (required by bash)
bash: /jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/xdoc/xdoc/libtinfo.so.5: no version information available (required by bash)
bash: /jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/xdoc/xdoc/libtinfo.so.5: no version information available (required by bash)
bash: /jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/xdoc/xdoc/libtinfo.so.5: no version information available (required by bash)
mkdir: symbol lookup error: mkdir: undefined symbol: mode_to_security_class
xmake[1]: [.build] Error 127 (ignored)
/jenkins/workspace/XMOS_lib_i2s_PR-59/Installs/Linux/External/Product/build/xcommon/module_xcommon/build/../build/Makefile.common1:974: *** open: .build/_iflag.rsp: No such file or directory.  Stop.
xmake: *** [analyze] Error 2
```