### PR TITLE
Re-apply original copyright years

### DIFF
--- a/examples/app_i2s_frame_slave_loopback_demo/src/main.xc
+++ b/examples/app_i2s_frame_slave_loopback_demo/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2014-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 #include <xs1.h>


### PR DESCRIPTION
The fixed infr_apps source checker can handle copyright dates that predate the git history, so re-apply the original copyright years.