### PR TITLE
Update tools version for xcore.ai hardware testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   parameters {
     string(
       name: 'TOOLS_VERSION',
-      defaultValue: '15.0.2',
+      defaultValue: '15.1.0',
       description: 'The tools version to build with (check /projects/tools/ReleasesTools/)'
       )
   }
@@ -74,7 +74,7 @@ pipeline {
       }
       environment {
         // '/XMOS/tools' from get_tools.py and rest from tools installers
-        TOOLS_PATH = "/XMOS/tools/${params.TOOLS_VERSION}/XMOS/xTIMEcomposer/${params.TOOLS_VERSION}"
+        TOOLS_PATH = "/XMOS/tools/${params.TOOLS_VERSION}/XMOS/XTC/${params.TOOLS_VERSION}"
       }
       stages{
         stage('Install Dependencies') {


### PR DESCRIPTION
This should reduce issues seen with incompatibility between tools versions <15.0.4 on xtags in the CI system