### PR TITLE
Guard 4b implementation against null ports

### DIFF
--- a/lib_i2s/src/i2s_frame_master_4b_impl.h
+++ b/lib_i2s/src/i2s_frame_master_4b_impl.h
@@ -52,15 +52,22 @@ static void i2s_frame_init_ports_4b(
         clock bclk
         ){
 
+    if (!isnull(p_dout))
+    {
+        configure_out_port(p_dout, bclk, 0);
+        clearbuf(p_dout);
+    }
     
-    configure_out_port(p_dout, bclk, 0);
-    configure_in_port(p_din, bclk);
-    configure_out_port(p_lrclk, bclk, 1);
-    configure_port_clock_output(p_bclk, bclk);
+    if (!isnull(p_din))
+    {
+        configure_in_port(p_din, bclk);
+        clearbuf(p_din);
+    }
 
-    clearbuf(p_dout);
-    clearbuf(p_din);
+    configure_out_port(p_lrclk, bclk, 1);
     clearbuf(p_lrclk);
+
+    configure_port_clock_output(p_bclk, bclk);
 }
 
 #pragma unsafe arrays
@@ -89,15 +96,19 @@ static i2s_restart_t i2s_frame_ratio_n_4b(
 
     p_lrclk @ 1 <: 0;
 
-    
-    asm volatile("setpt res[%0], %1"
+    if (!isnull(p_din))
+    {
+        asm volatile("setpt res[%0], %1"
                     :
                     :"r"(p_din), "r"(8 + offset));
-    
+    }
 
-    asm volatile("setpt res[%0], %1"
-                    :
-                    :"r"(p_dout), "r"(1 + offset));
+    if (!isnull(p_dout))
+    {
+        asm volatile("setpt res[%0], %1"
+                        :
+                        :"r"(p_dout), "r"(1 + offset));
+    }
 
     i2s_frame_master_4b_setup(out_samps, in_samps, p_dout, p_din, bclk, p_lrclk);
 

--- a/lib_i2s/src/i2s_frame_master_4b_loop_part_1.S
+++ b/lib_i2s/src/i2s_frame_master_4b_loop_part_1.S
@@ -43,22 +43,26 @@ FUNCTION_NAME:
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
 
+  // Split into input-only, output-only, or input-output body implementations
+  // If the input port is nulled (0), only output. Otherwise, proceed to input
     bf     inp_port, i2s_frame_master_4b_loop_part_1_out_body
 
 i2s_frame_master_4b_loop_part_1_in_body:
+  // If we are here and the output port is not null (non-0), then both in and 
+  // out are in use. Jump to the input-output implementation.
+  // Otherwise, just input.
     bt     out_port, i2s_frame_master_4b_loop_part_1_in_out_body
 
-    //output 32 bits of 0 for lr clock
+  // Output 32 bits of 0 for lr clock
     ldc    e, 0
     out    res[lr_clock], e
 
-    ldw    f, inp_array[1]
-    ldw    e, inp_array[3]
-    in     d, res[inp_port]
-    in     c, res[inp_port]
-
-    // Unzip the recieved odd samples as required
-    // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+  // Retrieve the two odd samples we stored earlier, and input the other two
+  { ldw    f, inp_array[1] ; in     d, res[inp_port] }
+  { ldw    e, inp_array[3] ; in     c, res[inp_port] }
+    
+  // Unzip the recieved odd samples as required
+  // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
     unzip  e, f, 0
     unzip  c, d, 0
     unzip  d, f, 0
@@ -73,6 +77,7 @@ i2s_frame_master_4b_loop_part_1_in_body:
   { stw    d, inp_array[3] ; bitrev c, c             } 
   { stw    c, inp_array[1] ;                         }
 
+  // Jump to the common end section
     bu     i2s_frame_master_4b_loop_part_1_final 
 
 i2s_frame_master_4b_loop_part_1_out_body:
@@ -91,12 +96,13 @@ i2s_frame_master_4b_loop_part_1_out_body:
     zip    a, b, 0
     zip    c, d, 0  
 
+  // Output the first two even samples. 
   // Stash the 3rd and 4th even samples for transmission later.
-  out    res[out_port], d
-  out    res[out_port], c
-  stw    a, out_array[0]
-  stw    b, out_array[2]
-    
+  { stw    a, out_array[0] ; out    res[out_port], d }
+  { stw    b, out_array[2] ; out    res[out_port], c }
+  
+  
+  // Jump to the common end section
     bu     i2s_frame_master_4b_loop_part_1_final 
 
 i2s_frame_master_4b_loop_part_1_in_out_body:
@@ -139,6 +145,8 @@ i2s_frame_master_4b_loop_part_1_in_out_body:
   { stw    e, inp_array[5] ; bitrev d, d             } 
   { stw    d, inp_array[3] ; bitrev c, c             } 
   { stw    c, inp_array[1] ;                         }
+
+  // Continue to common end section
 
 i2s_frame_master_4b_loop_part_1_final:
   // Restore registers and return.

--- a/lib_i2s/src/i2s_frame_master_4b_loop_part_1.S
+++ b/lib_i2s/src/i2s_frame_master_4b_loop_part_1.S
@@ -43,6 +43,64 @@ FUNCTION_NAME:
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
 
+    bf     inp_port, i2s_frame_master_4b_loop_part_1_out_body
+
+i2s_frame_master_4b_loop_part_1_in_body:
+    bt     out_port, i2s_frame_master_4b_loop_part_1_in_out_body
+
+    //output 32 bits of 0 for lr clock
+    ldc    e, 0
+    out    res[lr_clock], e
+
+    ldw    f, inp_array[1]
+    ldw    e, inp_array[3]
+    in     d, res[inp_port]
+    in     c, res[inp_port]
+
+    // Unzip the recieved odd samples as required
+    // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+    unzip  e, f, 0
+    unzip  c, d, 0
+    unzip  d, f, 0
+    unzip  c, e, 0 
+
+  // Bit-reverse and store the recieved odd samples. At this point, we have
+  // recieved all 8 samples and must call the recieve callback to pass these 
+  // to the user. 
+  {                        ; bitrev f, f             }
+  { stw    f, inp_array[7] ; bitrev e, e             } 
+  { stw    e, inp_array[5] ; bitrev d, d             } 
+  { stw    d, inp_array[3] ; bitrev c, c             } 
+  { stw    c, inp_array[1] ;                         }
+
+    bu     i2s_frame_master_4b_loop_part_1_final 
+
+i2s_frame_master_4b_loop_part_1_out_body:
+  // Load and bit-reverse the even 32-bit samples we intend to send
+  // Generate and output 32 bits of 0 for the lrclock
+  { ldw    a, out_array[0] ; ldc    e, 0             }
+  { ldw    b, out_array[2] ; out    res[lr_clock], e } 
+  { ldw    c, out_array[4] ; bitrev a, a             } 
+  { ldw    d, out_array[6] ; bitrev b, b             } 
+  { bitrev c, c            ; bitrev d, d             }
+
+  // Zip the even samples as required to send in parallel on a 4b port
+  // (abcd) (efgh) (ijkl) (mnop) -> aeim bfjn cgko dhlp
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+
+  // Stash the 3rd and 4th even samples for transmission later.
+  out    res[out_port], d
+  out    res[out_port], c
+  stw    a, out_array[0]
+  stw    b, out_array[2]
+    
+    bu     i2s_frame_master_4b_loop_part_1_final 
+
+i2s_frame_master_4b_loop_part_1_in_out_body:
+
   // Load and bit-reverse the even 32-bit samples we intend to send
   // Generate and output 32 bits of 0 for the lrclock
   { ldw    a, out_array[0] ; ldc    e, 0             }
@@ -82,6 +140,7 @@ FUNCTION_NAME:
   { stw    d, inp_array[3] ; bitrev c, c             } 
   { stw    c, inp_array[1] ;                         }
 
+i2s_frame_master_4b_loop_part_1_final:
   // Restore registers and return.
     ldw    lr_clock, sp[0]
     ldd    a, b, sp[1]

--- a/lib_i2s/src/i2s_frame_master_4b_loop_part_2.S
+++ b/lib_i2s/src/i2s_frame_master_4b_loop_part_2.S
@@ -43,6 +43,74 @@ FUNCTION_NAME:
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
 
+    bf     inp_port, i2s_frame_master_4b_loop_part_2_out_body
+
+i2s_frame_master_4b_loop_part_2_in_body:
+    bt     out_port, i2s_frame_master_4b_loop_part_2_in_out_body
+   
+    mkmsk  e, 32
+    out    res[lr_clock], e
+    in     f, res[inp_port]
+    in     e, res[inp_port]
+    in     d, res[inp_port]
+    in     c, res[inp_port]
+
+    // Unzip the recieved even samples as required
+  // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+    unzip  e, f, 0
+    unzip  c, d, 0
+    unzip  d, f, 0
+    unzip  c, e, 0 
+
+  // Bit-reverse and store the recieved even samples. 
+  {                        ; bitrev f, f             }
+  { stw    f, inp_array[6] ; bitrev e, e             } 
+  { stw    e, inp_array[4] ; bitrev d, d             } 
+  { stw    d, inp_array[2] ; bitrev c, c             } 
+  { stw    c, inp_array[0] ;                         }
+  
+   in     f, res[inp_port]
+   stw    f, inp_array[1] 
+   in     e, res[inp_port]
+   stw    e, inp_array[3] 
+
+    bu     i2s_frame_master_4b_loop_part_2_final 
+
+i2s_frame_master_4b_loop_part_2_out_body:
+  // We stashed the 3rd and 4th even samples for transmission earlier.
+  // Retrieve these and immediately transmit the 3rd.
+  { ldw    b, out_array[2] ;                         }
+  { ldw    a, out_array[0] ; out    res[out_port], b }
+
+  // Generate and output 32 bits of 1 for the lrclock.
+  // Output the 4th even sample
+  // Load the odd samples we intend to send
+  // Input the 1st even sample
+  { ldw    d, out_array[7] ; mkmsk  e, 32            }
+  { ldw    c, out_array[5] ; out    res[lr_clock], e }
+  { ldw    b, out_array[3] ;                         }
+  { ldw    a, out_array[1] ; out    res[out_port], a }
+
+  // Bit-reverse the odd samples
+  { bitrev d, d            ; bitrev c, c             }
+  { bitrev b, b            ; bitrev a, a             }
+
+  // Zip the odd samples as required to send in parallel on a 4b port
+  // (abcd) (efgh) (ijkl) (mnop) -> aeim bfjn cgko dhlp
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+
+  // Output the odd samples
+  out    res[out_port], d
+  out    res[out_port], c
+  out    res[out_port], b
+  out    res[out_port], a
+
+    bu     i2s_frame_master_4b_loop_part_2_final 
+
+i2s_frame_master_4b_loop_part_2_in_out_body:
   // We stashed the 3rd and 4th even samples for transmission earlier.
   // Retrieve these and immediately transmit the 3rd.
   { ldw    b, out_array[2] ;                         }
@@ -101,6 +169,7 @@ FUNCTION_NAME:
   {                        ; in     e, res[inp_port] }
   { stw    e, inp_array[3] ;                         }
 
+i2s_frame_master_4b_loop_part_2_final:
   // Restore registers and return.
     ldw    lr_clock, sp[0]
     ldd    a, b, sp[1]

--- a/lib_i2s/src/i2s_frame_master_4b_loop_part_2.S
+++ b/lib_i2s/src/i2s_frame_master_4b_loop_part_2.S
@@ -43,19 +43,27 @@ FUNCTION_NAME:
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
 
+  // Split into input-only, output-only, or input-output body implementations
+  // If the input port is nulled (0), only output. Otherwise, proceed to input
     bf     inp_port, i2s_frame_master_4b_loop_part_2_out_body
 
 i2s_frame_master_4b_loop_part_2_in_body:
+  // If we are here and the output port is not null (non-0), then both in and 
+  // out are in use. Jump to the input-output implementation.
+  // Otherwise, just input.
     bt     out_port, i2s_frame_master_4b_loop_part_2_in_out_body
-   
+
+  // Generate and output 32 bits of 1 to the LR clock 
     mkmsk  e, 32
     out    res[lr_clock], e
+
+  // Recieve the even samples
     in     f, res[inp_port]
     in     e, res[inp_port]
     in     d, res[inp_port]
     in     c, res[inp_port]
 
-    // Unzip the recieved even samples as required
+  // Unzip the recieved even samples as required
   // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
     unzip  e, f, 0
     unzip  c, d, 0
@@ -63,17 +71,19 @@ i2s_frame_master_4b_loop_part_2_in_body:
     unzip  c, e, 0 
 
   // Bit-reverse and store the recieved even samples. 
-  {                        ; bitrev f, f             }
-  { stw    f, inp_array[6] ; bitrev e, e             } 
-  { stw    e, inp_array[4] ; bitrev d, d             } 
-  { stw    d, inp_array[2] ; bitrev c, c             } 
-  { stw    c, inp_array[0] ;                         }
-  
-   in     f, res[inp_port]
-   stw    f, inp_array[1] 
-   in     e, res[inp_port]
-   stw    e, inp_array[3] 
+  {                        ; bitrev f, f              }
+  { stw    f, inp_array[6] ; bitrev e, e              } 
+  { stw    e, inp_array[4] ; bitrev d, d              } 
+  { stw    d, inp_array[2] ; bitrev c, c              } 
+  { stw    c, inp_array[0] ;                          }
 
+  // Input the first two odd samples. As we are returning from this function, 
+  // we must store these recieved samples in memory to pick up later.
+  {                         ; in     f, res[inp_port] }
+  { stw    f, inp_array[1]  ; in     e, res[inp_port] }
+  { stw    e, inp_array[3]  ;                         }
+
+  // Jump to the common end section
     bu     i2s_frame_master_4b_loop_part_2_final 
 
 i2s_frame_master_4b_loop_part_2_out_body:
@@ -103,11 +113,12 @@ i2s_frame_master_4b_loop_part_2_out_body:
     zip    c, d, 0  
 
   // Output the odd samples
-  out    res[out_port], d
-  out    res[out_port], c
-  out    res[out_port], b
-  out    res[out_port], a
+    out    res[out_port], d
+    out    res[out_port], c
+    out    res[out_port], b
+    out    res[out_port], a
 
+  // Jump to the common end section
     bu     i2s_frame_master_4b_loop_part_2_final 
 
 i2s_frame_master_4b_loop_part_2_in_out_body:
@@ -169,6 +180,8 @@ i2s_frame_master_4b_loop_part_2_in_out_body:
   {                        ; in     e, res[inp_port] }
   { stw    e, inp_array[3] ;                         }
 
+  // Continue to the common end section
+  
 i2s_frame_master_4b_loop_part_2_final:
   // Restore registers and return.
     ldw    lr_clock, sp[0]

--- a/lib_i2s/src/i2s_frame_master_4b_loop_part_2.S
+++ b/lib_i2s/src/i2s_frame_master_4b_loop_part_2.S
@@ -95,7 +95,7 @@ i2s_frame_master_4b_loop_part_2_out_body:
   // Generate and output 32 bits of 1 for the lrclock.
   // Output the 4th even sample
   // Load the odd samples we intend to send
-  // Input the 1st even sample
+  // Output the 4th even sample
   { ldw    d, out_array[7] ; mkmsk  e, 32            }
   { ldw    c, out_array[5] ; out    res[lr_clock], e }
   { ldw    b, out_array[3] ;                         }

--- a/lib_i2s/src/i2s_frame_master_4b_setup.S
+++ b/lib_i2s/src/i2s_frame_master_4b_setup.S
@@ -128,7 +128,8 @@ i2s_frame_master_4b_setup_out_body:
     zip    a, b, 0
     zip    c, d, 0  
     
-  // Output the odd samples
+  // Output the odd samples. At this point, we have transmitted all
+  // 8 samples, and must call the send callback to recieve the next batch.
   {                                  ; out    res[out_port], d }
   {                                  ; out    res[out_port], c }
   {                                  ; out    res[out_port], b }

--- a/lib_i2s/src/i2s_frame_master_4b_setup.S
+++ b/lib_i2s/src/i2s_frame_master_4b_setup.S
@@ -45,24 +45,30 @@ FUNCTION_NAME:
   // Retrieve final two arguments to function
     ldw    bt_clock, sp[9]
     ldw    lr_clock, sp[10]
-
+  
+  // Split into input-only, output-only, or input-output body implementations
+  // If the input port is nulled (0), only set up an output. Otherwise, proceed
+  // to set up an input.
     bf     inp_port, i2s_frame_master_4b_setup_out_body
 
 i2s_frame_master_4b_setup_in_body:
+  // If we are here and the output port is not null (non-0), then both in and 
+  // out are in use. Jump to the input-output implementation.
+  // Otherwise, just set up an input.
     bt     out_port, i2s_frame_master_4b_setup_in_out_body
 
-    // Start the bit clock
+  // Start the bit clock
     setc   res[bt_clock], 0xF
 
-    // Output 32 1s to lr_clock
+  // Output 32 1s to lr_clock
     mkmsk  e, 32                     
     out    res[lr_clock], e 
 
-    //input samples
-    in     f, res[inp_port]
-    in     e, res[inp_port]
-    in     d, res[inp_port]
-    in     c, res[inp_port]
+  // Input samples
+  {                                  ; in     f, res[inp_port] }
+  {                                  ; in     e, res[inp_port] }
+  {                                  ; in     d, res[inp_port] }
+  {                                  ; in     c, res[inp_port] }
 
   // Unzip the recieved even samples as required
   // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
@@ -78,11 +84,13 @@ i2s_frame_master_4b_setup_in_body:
   { stw    d, inp_array[2]           ; bitrev c, c             } 
   { stw    c, inp_array[0]           ;                         }
 
-    in     f, res[inp_port]
-    stw    f, inp_array[1]
-    in     e, res[inp_port]
-    stw    e, inp_array[3]
+  // Input the first two odd samples. As we are returning from this function, 
+  // we must store these recieved samples in memory to pick up later.
+  {                                  ; in     f, res[inp_port] }
+  { stw    f, inp_array[1]           ; in     e, res[inp_port] }
+  { stw    e, inp_array[3]           ;                         }
 
+  // Jump to the common end section
     bu     i2s_frame_master_4b_setup_final 
 
 i2s_frame_master_4b_setup_out_body:
@@ -121,10 +129,12 @@ i2s_frame_master_4b_setup_out_body:
     zip    c, d, 0  
     
   // Output the odd samples
-  out    res[out_port], d
-  out    res[out_port], c
-  out    res[out_port], b
-  out    res[out_port], a
+  {                                  ; out    res[out_port], d }
+  {                                  ; out    res[out_port], c }
+  {                                  ; out    res[out_port], b }
+  {                                  ; out    res[out_port], a }
+
+  // Jump to the common end section
     bu     i2s_frame_master_4b_setup_final 
 
 i2s_frame_master_4b_setup_in_out_body:
@@ -195,6 +205,8 @@ i2s_frame_master_4b_setup_in_out_body:
   { stw    f, inp_array[1]           ; out    res[out_port], a }
   {                                  ; in     e, res[inp_port] }
   { stw    e, inp_array[3]           ;                         }
+
+  // Continue to common end section
 
 i2s_frame_master_4b_setup_final:
   // Restore registers and return.

--- a/lib_i2s/src/i2s_frame_master_4b_setup.S
+++ b/lib_i2s/src/i2s_frame_master_4b_setup.S
@@ -46,6 +46,88 @@ FUNCTION_NAME:
     ldw    bt_clock, sp[9]
     ldw    lr_clock, sp[10]
 
+    bf     inp_port, i2s_frame_master_4b_setup_out_body
+
+i2s_frame_master_4b_setup_in_body:
+    bt     out_port, i2s_frame_master_4b_setup_in_out_body
+
+    // Start the bit clock
+    setc   res[bt_clock], 0xF
+
+    // Output 32 1s to lr_clock
+    mkmsk  e, 32                     
+    out    res[lr_clock], e 
+
+    //input samples
+    in     f, res[inp_port]
+    in     e, res[inp_port]
+    in     d, res[inp_port]
+    in     c, res[inp_port]
+
+  // Unzip the recieved even samples as required
+  // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+    unzip  e, f, 0
+    unzip  c, d, 0
+    unzip  d, f, 0
+    unzip  c, e, 0 
+
+  // Bit-reverse and store the recieved even samples
+  {                                  ; bitrev f, f             }
+  { stw    f, inp_array[6]           ; bitrev e, e             } 
+  { stw    e, inp_array[4]           ; bitrev d, d             } 
+  { stw    d, inp_array[2]           ; bitrev c, c             } 
+  { stw    c, inp_array[0]           ;                         }
+
+    in     f, res[inp_port]
+    stw    f, inp_array[1]
+    in     e, res[inp_port]
+    stw    e, inp_array[3]
+
+    bu     i2s_frame_master_4b_setup_final 
+
+i2s_frame_master_4b_setup_out_body:
+  // Load and bit-reverse the even 32-bit samples we intend to send
+  // Generate 32 bits of 1 for the lrclock
+  { ldw    a, out_array[0]           ;                         }
+  { ldw    b, out_array[2]           ; bitrev a, a             } 
+  { ldw    c, out_array[4]           ; bitrev b, b             } 
+  { ldw    d, out_array[6]           ; bitrev c, c             } 
+  { mkmsk  e, 32                     ; bitrev d, d             }
+
+  // Zip the even samples as required to send in parallel on a 4b port
+  // (abcd) (efgh) (ijkl) (mnop) -> aeim bfjn cgko dhlp
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+
+  // Load and bit-reverse the odd 32-bit samples we intend to send
+  // Output 32 1s to the lrclock transfer register
+  // Output the even samples
+  // Start the bit clock
+  { ldw    d, out_array[7]           ; out    res[out_port], d }
+    setc   res[bt_clock], 0xF
+  { ldw    c, out_array[5]           ; out    res[out_port], c }
+  { bitrev d, d                      ; out    res[lr_clock], e }
+  { ldw    b, out_array[3]           ; out    res[out_port], b }
+  { bitrev c, c                      ;                         }
+  { ldw    a, out_array[1]           ; out    res[out_port], a }
+  { bitrev b, b                      ; bitrev a, a             }
+
+  // Zip the odd samples as required to send in parallel on a 4b port
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+    
+  // Output the odd samples
+  out    res[out_port], d
+  out    res[out_port], c
+  out    res[out_port], b
+  out    res[out_port], a
+    bu     i2s_frame_master_4b_setup_final 
+
+i2s_frame_master_4b_setup_in_out_body:
   // Load and bit-reverse the even 32-bit samples we intend to send
   // Generate 32 bits of 1 for the lrclock
   { ldw    a, out_array[0]           ;                         }
@@ -114,6 +196,7 @@ FUNCTION_NAME:
   {                                  ; in     e, res[inp_port] }
   { stw    e, inp_array[3]           ;                         }
 
+i2s_frame_master_4b_setup_final:
   // Restore registers and return.
     ldd    bt_clock, lr_clock, sp[0] 
     ldd    a, b, sp[1]

--- a/lib_i2s/src/i2s_frame_slave_4b_impl.h
+++ b/lib_i2s/src/i2s_frame_slave_4b_impl.h
@@ -44,8 +44,16 @@ static void i2s_frame_slave_init_ports_4b(
     set_clock_on(bclk);
     configure_clock_src(bclk, p_bclk);
     configure_in_port(p_lrclk, bclk);
-    configure_out_port(p_dout, bclk, 0);
-    configure_in_port(p_din, bclk);
+    
+    if (!isnull(p_din))
+    {
+        configure_in_port(p_din, bclk);
+    }
+    if (!isnull(p_dout))
+    {
+        configure_out_port(p_dout, bclk, 0);
+    }
+
     start_clock(bclk);
 }
 
@@ -88,9 +96,14 @@ static void i2s_frame_slave_4b0(client i2s_frame_callback_if i2s_i,
 
         unsigned syncerror = 0;
         unsigned lrval;
-
-        clearbuf(p_dout);
-        clearbuf(p_din);
+        if (!isnull(p_dout))
+        {
+            clearbuf(p_dout);
+        }
+        if (!isnull(p_din))
+        {
+            clearbuf(p_din);
+        }
         clearbuf(p_lrclk);
 
         unsigned offset = (mode == I2S_MODE_I2S ? 1 : 0);
@@ -106,12 +119,18 @@ static void i2s_frame_slave_4b0(client i2s_frame_callback_if i2s_i,
         asm volatile("setpt res[%0], %1"
                    :
                    :"r"(p_lrclk),"r"(initial_lr_port_time));
-        asm volatile("setpt res[%0], %1"
-                   :
-                   :"r"(p_din),"r"(initial_in_port_time));
-        asm volatile("setpt res[%0], %1"
-                    :
-                    :"r"(p_dout),"r"(initial_out_port_time));
+        if (!isnull(p_din))
+        {
+            asm volatile("setpt res[%0], %1"
+                       :
+                       :"r"(p_din),"r"(initial_in_port_time));
+        }
+        if (!isnull(p_dout))
+        {
+            asm volatile("setpt res[%0], %1"
+                        :
+                        :"r"(p_dout),"r"(initial_out_port_time));
+        }
         
         //Get initial send data if output enabled
         if (num_out) 

--- a/lib_i2s/src/i2s_frame_slave_4b_loop_part_1.S
+++ b/lib_i2s/src/i2s_frame_slave_4b_loop_part_1.S
@@ -42,7 +42,68 @@ FUNCTION_NAME:
 
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
+  // Split into input-only, output-only, or input-output body implementations
+  // If the input port is nulled (0), only set up an output. Otherwise, proceed
+  // to set up an input.
+    bf     inp_port, i2s_frame_slave_4b_loop_part_1_out_body
 
+i2s_frame_slave_4b_loop_part_1_in_body:
+  // If we are here and the output port is not null (non-0), then both in and 
+  // out are in use. Jump to the input-output implementation.
+  // Otherwise, just set up an input.
+    bt     out_port, i2s_frame_slave_4b_loop_part_1_in_out_body
+
+  // Retrieve the two odd samples we stored earlier, and input the other two
+  { ldw    f, inp_array[1] ; in     d, res[inp_port]  }
+  { ldw    e, inp_array[3] ; in     c, res[inp_port]  }
+    
+  // Unzip the recieved odd samples as required
+  // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+    unzip  e, f, 0
+    unzip  c, d, 0
+    unzip  d, f, 0
+    unzip  c, e, 0 
+
+  // Bit-reverse and store the recieved odd samples. At this point, we have
+  // recieved all 8 samples and must call the recieve callback to pass these 
+  // to the user. 
+  // Input value of the lr_clock and return it
+  {                        ; bitrev f, f              }
+  { stw    f, inp_array[7] ; bitrev e, e              } 
+  { stw    e, inp_array[5] ; bitrev d, d              } 
+  { stw    d, inp_array[3] ; bitrev c, c              } 
+  { stw    c, inp_array[1] ; in     r0, res[lr_clock] }
+
+  // Jump to the common end section
+    bu     i2s_frame_slave_4b_loop_part_1_final 
+
+i2s_frame_slave_4b_loop_part_1_out_body:
+  // Load and bit-reverse the even 32-bit samples we intend to send
+  { ldw    a, out_array[0] ;                          }
+  { ldw    b, out_array[2] ; bitrev a, a              } 
+  { ldw    c, out_array[4] ; bitrev b, b              } 
+  { ldw    d, out_array[6] ; bitrev c, c              } 
+  {                        ; bitrev d, d              }
+
+  // Zip the even samples as required to send in parallel on a 4b port
+  // (abcd) (efgh) (ijkl) (mnop) -> aeim bfjn cgko dhlp
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+
+  // Output the first two even samples. 
+  // Stash the 3rd and 4th even samples for transmission later.
+  { stw    a, out_array[0] ; out    res[out_port], d  }
+  { stw    b, out_array[2] ; out    res[out_port], c  }
+
+  // Input value of the lr_clock and return it
+    in     r0, res[lr_clock]
+
+  // Jump to the common end section
+    bu     i2s_frame_slave_4b_loop_part_1_final 
+
+i2s_frame_slave_4b_loop_part_1_in_out_body:
   // Load and bit-reverse the even 32-bit samples we intend to send
   { ldw    a, out_array[0] ;                          }
   { ldw    b, out_array[2] ; bitrev a, a              } 
@@ -82,6 +143,9 @@ FUNCTION_NAME:
   { stw    d, inp_array[3] ; bitrev c, c              } 
   { stw    c, inp_array[1] ; in     r0, res[lr_clock] }
 
+  // Continue to common end section
+
+i2s_frame_slave_4b_loop_part_1_final:
   // Restore registers and return.
     ldw    lr_clock, sp[0]
     ldd    a, b, sp[1]

--- a/lib_i2s/src/i2s_frame_slave_4b_loop_part_2.S
+++ b/lib_i2s/src/i2s_frame_slave_4b_loop_part_2.S
@@ -42,7 +42,85 @@ FUNCTION_NAME:
 
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
+    
+  // Split into input-only, output-only, or input-output body implementations
+  // If the input port is nulled (0), only set up an output. Otherwise, proceed
+  // to set up an input.
+    bf     inp_port, i2s_frame_slave_4b_loop_part_2_out_body
 
+i2s_frame_slave_4b_loop_part_2_in_body:
+  // If we are here and the output port is not null (non-0), then both in and 
+  // out are in use. Jump to the input-output implementation.
+  // Otherwise, just set up an input.
+    bt     out_port, i2s_frame_slave_4b_loop_part_2_in_out_body
+
+  // Recieve the even samples
+    in     f, res[inp_port]
+    in     e, res[inp_port]
+    in     d, res[inp_port]
+    in     c, res[inp_port]
+
+  // Unzip the recieved even samples as required
+  // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+    unzip  e, f, 0
+    unzip  c, d, 0
+    unzip  d, f, 0
+    unzip  c, e, 0 
+
+  // Bit-reverse and store the recieved even samples. 
+  {                        ; bitrev f, f               }
+  { stw    f, inp_array[6] ; bitrev e, e               } 
+  { stw    e, inp_array[4] ; bitrev d, d               } 
+  { stw    d, inp_array[2] ; bitrev c, c               } 
+  { stw    c, inp_array[0] ;                           }
+
+  // Input the first two odd samples. As we are returning from this function, 
+  // we must store these recieved samples in memory to pick up later.
+  // Input the value of the lr clock and return it
+  {                         ; in     f, res[inp_port]  }
+  { stw    f, inp_array[1]  ; in     e, res[inp_port]  }
+  { stw    e, inp_array[3]  ; in     r0, res[lr_clock] }  
+
+  // Jump to the common end section
+    bu     i2s_frame_slave_4b_loop_part_2_final 
+
+i2s_frame_slave_4b_loop_part_2_out_body:
+  // We stashed the 3rd and 4th even samples for transmission earlier.
+  // Retrieve these and immediately transmit the 3rd.
+  { ldw    b, out_array[2] ;                         }
+  { ldw    a, out_array[0] ; out    res[out_port], b }
+
+  // Output the 4th even sample
+  // Load the odd samples we intend to send
+  { ldw    d, out_array[7] ;                         }
+  { ldw    c, out_array[5] ;                         }
+  { ldw    b, out_array[3] ;                         }
+  { ldw    a, out_array[1] ; out    res[out_port], a }
+
+  // Bit-reverse the odd samples
+  { bitrev d, d            ; bitrev c, c             }
+  { bitrev b, b            ; bitrev a, a             }
+
+  // Zip the odd samples as required to send in parallel on a 4b port
+  // (abcd) (efgh) (ijkl) (mnop) -> aeim bfjn cgko dhlp
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+
+  // Output the odd samples
+    out    res[out_port], d
+    out    res[out_port], c
+    out    res[out_port], b
+    out    res[out_port], a
+
+  // Input the value of the lr clock and return it
+    in     r0, res[lr_clock]
+
+  // Jump to the common end section
+    bu     i2s_frame_slave_4b_loop_part_2_final 
+
+i2s_frame_slave_4b_loop_part_2_in_out_body:
   // We stashed the 3rd and 4th even samples for transmission earlier.
   // Retrieve these and immediately transmit the 3rd.
   { ldw    b, out_array[2] ;                          }
@@ -101,6 +179,9 @@ FUNCTION_NAME:
   {                        ; in     e, res[inp_port]  }
   { stw    e, inp_array[3] ; in     r0, res[lr_clock] }
 
+  // Continue to common end section
+
+i2s_frame_slave_4b_loop_part_2_final:
   // Restore registers and return.
     ldw    lr_clock, sp[0]
     ldd    a, b, sp[1]

--- a/lib_i2s/src/i2s_frame_slave_4b_setup.S
+++ b/lib_i2s/src/i2s_frame_slave_4b_setup.S
@@ -42,7 +42,92 @@ FUNCTION_NAME:
 
   // Retrieve final argument to the function.
     ldw    lr_clock, sp[9]
+    
+  // Split into input-only, output-only, or input-output body implementations
+  // If the input port is nulled (0), only set up an output. Otherwise, proceed
+  // to set up an input.
+    bf     inp_port, i2s_frame_slave_4b_setup_out_body
 
+i2s_frame_slave_4b_setup_in_body:
+  // If we are here and the output port is not null (non-0), then both in and 
+  // out are in use. Jump to the input-output implementation.
+  // Otherwise, just set up an input.
+    bt     out_port, i2s_frame_slave_4b_setup_in_out_body
+
+  // Input samples
+  {                                  ; in     f, res[inp_port] }
+  {                                  ; in     e, res[inp_port] }
+  {                                  ; in     d, res[inp_port] }
+  {                                  ; in     c, res[inp_port] }
+
+  // Unzip the recieved even samples as required
+  // aeim bfjn cgko dhlp -> (abcd) (efgh) (ijkl) (mnop)
+    unzip  e, f, 0
+    unzip  c, d, 0
+    unzip  d, f, 0
+    unzip  c, e, 0 
+
+  // Bit-reverse and store the recieved even samples
+  {                                  ; bitrev f, f             }
+  { stw    f, inp_array[6]           ; bitrev e, e             } 
+  { stw    e, inp_array[4]           ; bitrev d, d             } 
+  { stw    d, inp_array[2]           ; bitrev c, c             } 
+  { stw    c, inp_array[0]           ;                         }
+
+  // Input the first two odd samples. As we are returning from this function, 
+  // we must store these recieved samples in memory to pick up later.
+  // Input the value of the lr_clock and return it
+  {                                  ; in     f, res[inp_port]  }
+  { stw    f, inp_array[1]           ; in     e, res[inp_port]  }
+  { stw    e, inp_array[3]           ; in     r0, res[lr_clock] }
+
+  // Jump to the common end section
+    bu     i2s_frame_slave_4b_setup_final 
+
+i2s_frame_slave_4b_setup_out_body:
+  // Load and bit-reverse the even 32-bit samples we intend to send
+  { ldw    a, out_array[0]           ;                         }
+  { ldw    b, out_array[2]           ; bitrev a, a             } 
+  { ldw    c, out_array[4]           ; bitrev b, b             } 
+  { ldw    d, out_array[6]           ; bitrev c, c             } 
+  {                                  ; bitrev d, d             }
+
+  // Zip the even samples as required to send in parallel on a 4b port
+  // (abcd) (efgh) (ijkl) (mnop) -> aeim bfjn cgko dhlp
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+
+  // Load and bit-reverse the odd 32-bit samples we intend to send
+  // Output the even samples
+  { ldw    d, out_array[7]           ; out    res[out_port], d }
+  { ldw    c, out_array[5]           ; out    res[out_port], c }
+  { bitrev d, d                      ; bitrev c, c             }
+  { ldw    b, out_array[3]           ; out    res[out_port], b }
+  { ldw    a, out_array[1]           ; out    res[out_port], a }
+  { bitrev b, b                      ; bitrev a, a             }
+
+  // Zip the odd samples as required to send in parallel on a 4b port
+    zip    a, c, 0
+    zip    b, d, 0
+    zip    a, b, 0
+    zip    c, d, 0  
+    
+  // Output the odd samples. At this point, we have transmitted all
+  // 8 samples, and must call the send callback to recieve the next batch.
+  {                                  ; out    res[out_port], d }
+  {                                  ; out    res[out_port], c }
+  {                                  ; out    res[out_port], b }
+  {                                  ; out    res[out_port], a }
+
+  // Input the value of the lr_clock and return it
+    in     r0, res[lr_clock]
+
+  // Jump to the common end section
+    bu     i2s_frame_slave_4b_setup_final 
+
+i2s_frame_slave_4b_setup_in_out_body:
   // Load and bit-reverse the even 32-bit samples we intend to send
   { ldw    a, out_array[0]           ;                          }
   { ldw    b, out_array[2]           ; bitrev a, a              } 
@@ -108,6 +193,9 @@ FUNCTION_NAME:
   {                                  ; in     e, res[inp_port]  }
   { stw    e, inp_array[3]           ; in     r0, res[lr_clock] }
 
+  // Continue to common end section
+
+i2s_frame_slave_4b_setup_final:
   // Restore registers and return.
     ldd    a, b, sp[0]
     ldd    c, d, sp[1]

--- a/tests/i2s_frame_master_4b_test/src/main.xc
+++ b/tests/i2s_frame_master_4b_test/src/main.xc
@@ -8,19 +8,6 @@
 
 #define IS_POWER_OF_2(x) ((x) && !((x) & ((x) - 1)))
 
-in port p_mclk  = XS1_PORT_1A;
-out port p_bclk = XS1_PORT_1B;
-out buffered port:32 p_lrclk = XS1_PORT_1C;
-
-in buffered port:32   p_din =  {XS1_PORT_4E};
-out buffered port:32  p_dout = {XS1_PORT_4F};
-
-clock bclk = XS1_CLKBLK_2;
-
-out port setup_strobe_port = XS1_PORT_1L;
-out port setup_data_port = XS1_PORT_16A;
-in port  setup_resp_port = XS1_PORT_1M;
-
 #define MAX_RATIO (4)
 #define MAX_CHANNELS (8)
 #define MAX_SAMPLE_RATE (192000)
@@ -37,6 +24,28 @@ in port  setup_resp_port = XS1_PORT_1M;
 #ifndef NUM_IN
 #define NUM_IN (4)
 #endif
+
+in port p_mclk  = XS1_PORT_1A;
+out port p_bclk = XS1_PORT_1B;
+out buffered port:32 p_lrclk = XS1_PORT_1C;
+
+#if NUM_IN
+    in buffered port:32   ?p_din =  {XS1_PORT_4E};
+#else
+    in buffered port:32   ?p_din =  null;
+#endif
+
+#if NUM_OUT
+    out buffered port:32  ?p_dout = {XS1_PORT_4F};
+#else
+    out buffered port:32  ?p_dout = null;
+#endif
+
+clock bclk = XS1_CLKBLK_2;
+
+out port setup_strobe_port = XS1_PORT_1L;
+out port setup_data_port = XS1_PORT_16A;
+in port  setup_resp_port = XS1_PORT_1M;
 
 #if defined(SMOKE)
 #if NUM_OUT > 1 || NUM_IN > 1

--- a/tests/i2s_frame_slave_4b_test/src/i2s_frame_slave_test.xc
+++ b/tests/i2s_frame_slave_4b_test/src/i2s_frame_slave_test.xc
@@ -8,8 +8,17 @@
 in port p_bclk = XS1_PORT_1B;
 in buffered port:32 p_lrclk = XS1_PORT_1C;
 
-in buffered port:32 p_din = XS1_PORT_4E;
-out buffered port:32  p_dout = XS1_PORT_4F;
+#if NUM_IN
+    in buffered port:32   ?p_din =  {XS1_PORT_4E};
+#else
+   in buffered port:32   ?p_din =  null;
+#endif
+
+#if NUM_OUT
+    out buffered port:32  ?p_dout = {XS1_PORT_4F};
+#else
+    out buffered port:32  ?p_dout = null;
+#endif
 
 clock bclk = XS1_CLKBLK_1;
 

--- a/tests/test_basic_frame_master_4b.py
+++ b/tests/test_basic_frame_master_4b.py
@@ -75,8 +75,8 @@ def do_master_test(data_bits, num_in, num_out, testlevel):
 
 
 def runtest():
+    do_master_test(32, 0, 4, "smoke")
+    do_master_test(32, 4, 0, "smoke")
     do_master_test(32, 4, 4, "smoke")
     do_master_test(32, 1, 1, "smoke")
-    do_master_test(32, 4, 0, "smoke")
-    do_master_test(32, 0, 4, "smoke")
     do_master_test(32, 4, 4, "nightly")

--- a/tests/test_basic_frame_master_4b.py
+++ b/tests/test_basic_frame_master_4b.py
@@ -75,8 +75,8 @@ def do_master_test(data_bits, num_in, num_out, testlevel):
 
 
 def runtest():
-    do_master_test(32, 0, 4, "smoke")
-    do_master_test(32, 4, 0, "smoke")
     do_master_test(32, 4, 4, "smoke")
     do_master_test(32, 1, 1, "smoke")
+    do_master_test(32, 4, 0, "smoke")
+    do_master_test(32, 0, 4, "smoke")
     do_master_test(32, 4, 4, "nightly")


### PR DESCRIPTION
Adds behaviour to the 4b port implementations of frame_master and _slave to correctly operate in the event that the user specifies a nulled input or output port.

This alters test behaviour - if NUM_IN or NUM_OUT are set to 0 for the 4b port tests, these will be set to `null` in the test. 
This introduces a test escape - no tests are now performed for the 4b implementation for non-null but empty input or output port lists. This should be rectified (along with dedicated tests written for both behaviours) in future work. 

Closes #114 