### PR TITLE
Cleanup the i2s tests

### DIFF
--- a/tests/backpressure_test/src/main.xc
+++ b/tests/backpressure_test/src/main.xc
@@ -38,6 +38,145 @@
 #define MASTER_CLOCK_FREQUENCY (24576000)
 #endif
 
+enum {
+    SAMPLE_RATE_192000,
+    SAMPLE_RATE_384000,
+    NUM_SAMPLE_RATES
+}e_sample_rates;
+
+enum {
+    BITDEPTH_8,
+    BITDEPTH_16,
+    BITDEPTH_32,
+    NUM_BIT_DEPTHS
+}e_bit_depth;
+
+enum {
+    NUM_I2S_LINES_1,
+    NUM_I2S_LINES_2,
+    NUM_I2S_LINES_3,
+    NUM_I2S_LINES_4,
+}e_channel_config;
+
+static int acceptable_receive_delay = 0, acceptable_send_delay = 0;
+static int acceptable_delay_ticks[NUM_SAMPLE_RATES][NUM_I2S_LINES_4+1][NUM_BIT_DEPTHS];
+
+static inline void populate_acceptable_delay_ticks()
+{
+    // These numbers are logged by running the test and logging the delay at the last passing iteration
+    // before the backpressure test starts failing. So, on top of the bare minimum code in the i2s_send()
+    // and i2s_receive() functions in this file plus their calling overheads, we have acceptable_delay_ticks number
+    // of cycles per send and receive callback function call to add any extra processing.
+
+    // 192 KHz
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_1][BITDEPTH_8] = 185;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_1][BITDEPTH_16] = 190;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_1][BITDEPTH_32] = 200;
+
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_2][BITDEPTH_8] = 155;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_2][BITDEPTH_16] = 165;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_2][BITDEPTH_32] = 180;
+
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_3][BITDEPTH_8] = 125;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_3][BITDEPTH_16] = 135;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_3][BITDEPTH_32] = 160;
+
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_4][BITDEPTH_8] = 100;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_4][BITDEPTH_16] = 100;
+    acceptable_delay_ticks[SAMPLE_RATE_192000][NUM_I2S_LINES_4][BITDEPTH_32] = 125;
+
+    // 384 KHz
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_1][BITDEPTH_8] = 65;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_1][BITDEPTH_16] = 70;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_1][BITDEPTH_32] = 75;
+
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_2][BITDEPTH_8] = 35;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_2][BITDEPTH_16] = 40;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_2][BITDEPTH_32] = 50;
+
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_3][BITDEPTH_8] = 5;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_3][BITDEPTH_16] = 5;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_3][BITDEPTH_32] = 25;
+
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_4][BITDEPTH_8] = 0;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_4][BITDEPTH_16] = 0;
+    acceptable_delay_ticks[SAMPLE_RATE_384000][NUM_I2S_LINES_4][BITDEPTH_32] = 5;
+}
+
+void get_acceptable_delay()
+{
+    int sample_rate;
+    if(SAMPLE_FREQUENCY == 192000)
+    {
+        sample_rate = SAMPLE_RATE_192000;
+    }
+    else if(SAMPLE_FREQUENCY == 384000)
+    {
+        sample_rate = SAMPLE_RATE_384000;
+    }
+    else
+    {
+        debug_printf("ERROR: Invalid sample rate %d\n", SAMPLE_FREQUENCY);
+        _Exit(1);
+    }
+
+    int bit_depth;
+    if(DATA_BITS == 8)
+    {
+        bit_depth = BITDEPTH_8;
+    }
+    else if(DATA_BITS == 16)
+    {
+        bit_depth = BITDEPTH_16;
+    }
+    else if(DATA_BITS == 32)
+    {
+        bit_depth = BITDEPTH_32;
+    }
+    else
+    {
+        debug_printf("ERROR: Invalid bit_depth %d\n", DATA_BITS);
+        _Exit(1);
+    }
+    if((NUM_I2S_LINES < 1) || (NUM_I2S_LINES > 4))
+    {
+        debug_printf("ERROR: Invalid NUM_I2S_LINES %d\n", NUM_I2S_LINES);
+        _Exit(1);
+    }
+    int delay = acceptable_delay_ticks[sample_rate][NUM_I2S_LINES-1][bit_depth];
+
+    if(delay <= 0)
+    {
+        debug_printf("ERROR: Invalid delay %d. Check if testing an unsupported configuration\n", delay);
+        _Exit(1);
+    }
+
+    // get the send and receive delay based on the
+    if((RECEIVE_DELAY_INCREMENT == 5) && (SEND_DELAY_INCREMENT == 5))
+    {
+        // Backpressure passes at delay, so add another increment number of ticks to get to the first fail instance
+        acceptable_receive_delay = delay + 5;
+        acceptable_send_delay = delay + 5;
+    }
+    else if((RECEIVE_DELAY_INCREMENT == 0) && (SEND_DELAY_INCREMENT == 10))
+    {
+        // Backpressure passes at 2*delay, so add another increment number of ticks to get to the first fail instance
+        acceptable_receive_delay = 0;
+        acceptable_send_delay = 2*delay + 10;
+    }
+    else if((RECEIVE_DELAY_INCREMENT == 10) && (SEND_DELAY_INCREMENT == 0))
+    {
+        // Backpressure passes at 2*delay, so add another increment number of ticks to get to the first fail instance
+        acceptable_receive_delay = 2*delay + 10;
+        acceptable_send_delay = 0;
+    }
+    else
+    {
+        debug_printf("ERROR: Unsupported receive (%d) and send (%d) delay increment combination\n", RECEIVE_DELAY_INCREMENT, SEND_DELAY_INCREMENT);
+        _Exit(1);
+    }
+}
+
 /* Ports and clocks used by the application */
 on tile[0]: out buffered port:32 p_lrclk = XS1_PORT_1G;
 on tile[0]: out port p_bclk = XS1_PORT_1H;
@@ -54,6 +193,7 @@ int send_delay = 0;
 unsafe{
     int * unsafe p_receive_delay= &receive_delay;
     int * unsafe p_send_delay = &send_delay;
+    static int32_t receive_data_store[8];
 }
 
 [[distributable]]
@@ -67,6 +207,10 @@ void i2s_loopback(server i2s_frame_callback_if i2s)
       break;
 
     case i2s.receive(size_t num_chan_in, int32_t sample[num_chan_in]):
+      for (size_t i = 0; i < num_chan_in; i++) {
+        receive_data_store[i] = sample[i];
+      }
+
       if (receive_delay) {
         delay_ticks(receive_delay);
       }
@@ -87,12 +231,6 @@ void i2s_loopback(server i2s_frame_callback_if i2s)
     }
   }
 }
-
-#if DATA_BITS == 32
-#define OVERHEAD_TICKS (160) // Some of the period needs to be allowed for the interface handling
-#else
-#define OVERHEAD_TICKS (222)
-#endif
 
 #define JITTER (1)   //Allow for rounding so does not break when diff = period + 1
 #define N_CYCLES_AT_DELAY (1) //How many LR clock cycles to measure at each backpressure delay value
@@ -119,23 +257,35 @@ void test_lr_period(void){
       while (1) {
           p_lr_test when pinseq(0) :> void;
           counter++;
+
+          p_lr_test when pinseq(1) :> void @ time;
+          int diff = DIFF_WRAP_16(time, time_old);
+
+          if (diff > (period + JITTER)) {
+            if(receive_delay < acceptable_receive_delay)
+            {
+                printf("Backpressure breaks at receive delay ticks = %d, acceptable receive delay = %d\n",
+                    receive_delay, acceptable_receive_delay);
+                printf("actual diff: %d, maximum (period + Jitter): %d\n", diff, (period + JITTER));
+                _Exit(1);
+            }
+
+            // The delay we're able to add in the i2s_send() function should be acceptable_send_delay ticks or more
+            if(send_delay < acceptable_send_delay)
+            {
+                printf("Backpressure breaks at send delay ticks = %d, acceptable send delay = %d\n",
+                    send_delay, acceptable_send_delay);
+                printf("actual diff: %d, maximum (period + Jitter): %d\n", diff, (period + JITTER));
+                _Exit(1);
+            }
+            printf("PASS\n");
+            _Exit(0);
+          }
+
           if (counter == N_CYCLES_AT_DELAY) {
               *(p_receive_delay) += RECEIVE_DELAY_INCREMENT;
               *(p_send_delay) += SEND_DELAY_INCREMENT;
-              if ((*p_receive_delay + *p_send_delay) > (period - OVERHEAD_TICKS)) {
-                debug_printf("PASS\n");
-                _Exit(0);
-              }
               counter = 0;
-          }
-          p_lr_test when pinseq(1) :> void @ time;
-          int diff = DIFF_WRAP_16(time, time_old);
-          if (diff > (period + JITTER)) {
-              debug_printf("Backpressure breaks at receive delay ticks=%d, send delay ticks=%d\n",
-                *p_receive_delay, *p_send_delay);
-              debug_printf("actual diff: %d, maximum (period + Jitter): %d\n",
-                diff, (period + JITTER));
-              _Exit(1);
           }
           time_old = time;
       }
@@ -153,6 +303,8 @@ int main()
 
   par {
     on tile[0]: {
+      populate_acceptable_delay_ticks();
+      get_acceptable_delay();
 #if GENERATE_MCLK
       // Generate a 25Mhz clock internally and drive p_mclk from that
       debug_printf("Using divided reference clock\n");
@@ -162,14 +314,13 @@ int main()
       set_port_mode_clock(p_mclk);
       start_clock(mclk);
 #endif
-      i2s_frame_master(i_i2s, p_dout, NUM_I2S_LINES, p_din, NUM_I2S_LINES, DATA_BITS, p_bclk, p_lrclk, p_mclk, bclk);
+      par {
+        i2s_frame_master(i_i2s, p_dout, NUM_I2S_LINES, p_din, NUM_I2S_LINES, DATA_BITS, p_bclk, p_lrclk, p_mclk, bclk);
+        [[distribute]] i2s_loopback(i_i2s);
+        test_lr_period();
+        par (int i=0; i<BURN_THREADS; i++) {burn();};
+      }
     }
-
-    on tile[0]: [[distribute]] i2s_loopback(i_i2s);
-
-    on tile[0]: test_lr_period();
-
-    on tile[0]: par (int i=0; i<BURN_THREADS; i++) {burn();};
   }
   return 0;
 }

--- a/tests/backpressure_test/src/main.xc
+++ b/tests/backpressure_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 #include <xs1.h>

--- a/tests/i2s_master_test/src/main.xc
+++ b/tests/i2s_master_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_slave_test/src/i2s_slave_test.xc
+++ b/tests/i2s_slave_test/src/i2s_slave_test.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_slave_test/src/i2s_slave_test.xc
+++ b/tests/i2s_slave_test/src/i2s_slave_test.xc
@@ -20,17 +20,14 @@ in port  setup_resp_port = XS1_PORT_1M;
 #define MAX_CHANNELS (8)
 
 #if defined(SMOKE)
-#define NUM_BCLKS (1)
-#define NUM_BCLKS_TO_CHECK (1)
-static const unsigned bclk_freq_lut[NUM_BCLKS] = {
-  1228800
+#define NUM_LRCLKS_TO_CHECK 1
+static const unsigned lr_freq_lut[] = {
+  192000
 };
 #else
-#define NUM_BCLKS (10)
-#define NUM_BCLKS_TO_CHECK (3)
-static const unsigned bclk_freq_lut[NUM_BCLKS] = {
-  1228800, 614400, 384000, 192000, 44100,
-  22050, 96000, 176400, 88200, 48000, 24000, 352800
+#define NUM_LRCLKS_TO_CHECK 6
+static const unsigned lr_freq_lut[] = {
+  192000, 176400, 96000, 88200, 48000, 44100
 };
 #endif
 
@@ -93,7 +90,7 @@ static int request_response(
 [[distributable]]
 #pragma unsafe arrays
 void app(server interface i2s_callback_if i2s_i){
-    unsigned bclk_freq_index = 0;
+    unsigned lr_freq_index = 0;
     unsigned frames_sent = 0;
     unsigned rx_data_counter[MAX_CHANNELS] = {0};
     unsigned tx_data_counter[MAX_CHANNELS] = {0};
@@ -136,15 +133,15 @@ void app(server interface i2s_callback_if i2s_i){
                     printf("Error\n");
                 }
 
-                if (bclk_freq_index == NUM_BCLKS_TO_CHECK-1) {
+                if (lr_freq_index == NUM_LRCLKS_TO_CHECK-1) {
                     if (current_mode == I2S_MODE_I2S) {
                         current_mode = I2S_MODE_LEFT_JUSTIFIED;
-                        bclk_freq_index = 0;
+                        lr_freq_index = 0;
                     } else {
                         _Exit(1);
                     }
                 } else {
-                    bclk_freq_index++;
+                    lr_freq_index++;
                 }
             }
 
@@ -159,7 +156,8 @@ void app(server interface i2s_callback_if i2s_i){
                 rx_data_counter[i] = 0;
             }
 
-            broadcast(bclk_freq_lut[bclk_freq_index],
+            unsigned bclk_freq = lr_freq_lut[lr_freq_index] * 32 * I2S_CHANS_PER_FRAME;
+            broadcast(bclk_freq,
                     NUM_IN, NUM_OUT, i2s_config.mode == I2S_MODE_I2S);
 
             break;

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 XMOS LIMITED.
+# Copyright 2016-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import pytest
 import Pyxsim

--- a/tests/test_basic_master.py
+++ b/tests/test_basic_master.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import I2SMasterChecker, Clock
 from pathlib import Path

--- a/tests/test_basic_slave.py
+++ b/tests/test_basic_slave.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_slave_checker import I2SSlaveChecker
 from i2s_master_checker import Clock

--- a/tests/test_basic_slave.py
+++ b/tests/test_basic_slave.py
@@ -51,7 +51,7 @@ def test_i2s_basic_slave(capfd, request, nightly, num_in, num_out):
             tester=tester,
             simthreads=[clk, checker],
             build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
-            #simargs=[],
+            clean_before_build=True,
             simargs=[
                 "--vcd-tracing",
                 f"-o i2s_trace_{num_in}_{num_out}.vcd -tile tile[0] -cycles -ports -ports-detailed -cores -instructions",
@@ -66,6 +66,7 @@ def test_i2s_basic_slave(capfd, request, nightly, num_in, num_out):
             tester=tester,
             simthreads=[clk, checker],
             build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+            clean_before_build=True,
             simargs=[],
             capfd=capfd
         )

--- a/tests/test_basic_slave.py
+++ b/tests/test_basic_slave.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import Pyxsim
 import pytest
 
+DEBUG = False
+
 num_in_out_args = {"4ch_in,4ch_out": (4, 4),
+                   "2ch_in,2ch_out": (2, 2),
                    "1ch_in,1ch_out": (1, 1),
                    "4ch_in,0ch_out": (4, 0),
                    "0ch_in,4ch_out": (0, 4)}
@@ -32,7 +35,7 @@ def test_i2s_basic_slave(capfd, request, nightly, num_in, num_out):
         "tile[0]:XS1_PORT_1M",
          clk,
          False, # Don't check the bclk stops precisely as the hardware can't do that
-         False) # We're not running frame-based, so assume 32b data 
+         False) # We're not running frame-based, so assume 32b data
 
     tester = Pyxsim.testers.AssertiveComparisonTester(
         f'{cwd}/expected/slave_test.expect',
@@ -42,11 +45,27 @@ def test_i2s_basic_slave(capfd, request, nightly, num_in, num_out):
         ignore=["CONFIG:.*"]
     )
 
-    Pyxsim.run_on_simulator(
-        binary,
-        tester=tester,
-        simthreads=[clk, checker],
-        build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
-        simargs=[],
-        capfd=capfd
-    )
+    if DEBUG:
+        Pyxsim.run_on_simulator(
+            binary,
+            tester=tester,
+            simthreads=[clk, checker],
+            build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+            #simargs=[],
+            simargs=[
+                "--vcd-tracing",
+                f"-o i2s_trace_{num_in}_{num_out}.vcd -tile tile[0] -cycles -ports -ports-detailed -cores -instructions",
+                "--trace-to",
+                f"i2s_trace_{num_in}_{num_out}.txt",
+            ],
+            capfd=capfd
+        )
+    else:
+        Pyxsim.run_on_simulator(
+            binary,
+            tester=tester,
+            simthreads=[clk, checker],
+            build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+            simargs=[],
+            capfd=capfd
+        )

--- a/tests/test_slave_bclk_invert.py
+++ b/tests/test_slave_bclk_invert.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_slave_checker import I2SSlaveChecker
 from i2s_master_checker import Clock

--- a/tests/test_slave_bclk_invert.py
+++ b/tests/test_slave_bclk_invert.py
@@ -6,8 +6,13 @@ from pathlib import Path
 import Pyxsim
 import pytest
 
-num_in_out_args = {"2ch_in,2ch_out": (2, 2)}
-
+num_in_out_args = {
+    "4ch_in,4ch_out": (4, 4),
+    "2ch_in,2ch_out": (2, 2),
+    "1ch_in,1ch_out": (1, 1),
+    "4ch_in,0ch_out": (4, 0),
+    "0ch_in,4ch_out": (0, 4),
+}
 @pytest.mark.parametrize(("num_in", "num_out"), num_in_out_args.values(), ids=num_in_out_args.keys())
 def test_i2s_basic_slave_invert(capfd, request, nightly, num_in, num_out):
     testlevel = '0' if nightly else '1'
@@ -28,8 +33,8 @@ def test_i2s_basic_slave_invert(capfd, request, nightly, num_in, num_out):
         "tile[0]:XS1_PORT_16A",
         "tile[0]:XS1_PORT_1M",
          clk,
-         invert_bclk=True, 
-         frame_based=False) # We're not running frame-based, so assume 32b data 
+         invert_bclk=True,
+         frame_based=False) # We're not running frame-based, so assume 32b data
 
     tester = Pyxsim.testers.AssertiveComparisonTester(
         f'{cwd}/expected/bclk_invert.expect',


### PR DESCRIPTION
https://xmosjira.atlassian.net/browse/AP-370

In this PR:
- Modified test_basic_slave and test_slave_bclk_invert to test the correct sampling frequencies (192, 96 and 48KHz)
- Modified test_basic_master to test correct sampling frequencies (192, 96 and 48 when num channels < 4, 96 and 48KHz when num channels = 4)
- Rewrote test_backpressure to test something sensible.