### PR TITLE
Fix more tests

### DIFF
--- a/tests/i2s_frame_master_4b_test/Makefile
+++ b/tests/i2s_frame_master_4b_test/Makefile
@@ -18,7 +18,7 @@ endif
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to
 # the project name
-APP_NAME = 
+APP_NAME =
 
 # The USED_MODULES variable lists other module used by the application.
 USED_MODULES = lib_i2s
@@ -32,21 +32,17 @@ USED_MODULES = lib_i2s
 COMMON_FLAGS = -O3 -g -save-temps
 
 NUMS_IN_OUT ?= 4;4 1;1 4;0 0;4
-SMOKE ?= 1
+MCLK_FAMILY ?= 48
 
-ifeq ($(SMOKE), 1)
-  $(foreach in_out,$(NUMS_IN_OUT), \
+
+$(foreach in_out,$(NUMS_IN_OUT), \
+  $(foreach mclk,$(MCLK_FAMILY), \
     $(eval \
-      XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_smoke = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE\
+      XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk) = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DMCLK_FAMILY=$(mclk)\
     ) \
-  ) 
-else
-  $(foreach in_out,$(NUMS_IN_OUT), \
-    $(eval \
-      XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out))) = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out)))\
-    ) \
-  ) 
-endif
+  ) \
+)
+
 
 XMOS_MAKE_PATH ?= ../..
 -include $(XMOS_MAKE_PATH)/xcommon/module_xcommon/build/Makefile.common

--- a/tests/i2s_frame_master_4b_test/src/main.xc
+++ b/tests/i2s_frame_master_4b_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_frame_master_external_clock_4b_test/Makefile
+++ b/tests/i2s_frame_master_external_clock_4b_test/Makefile
@@ -18,7 +18,7 @@ endif
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to
 # the project name
-APP_NAME = 
+APP_NAME =
 
 # The USED_MODULES variable lists other module used by the application.
 USED_MODULES = lib_i2s
@@ -32,21 +32,12 @@ USED_MODULES = lib_i2s
 COMMON_FLAGS = -O3 -g -save-temps
 
 NUMS_IN_OUT ?= 4;4 1;1 4;0 0;4
-SMOKE ?= 1
 
-ifeq ($(SMOKE), 1)
-  $(foreach in_out,$(NUMS_IN_OUT), \
-    $(eval \
-      XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_smoke = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE\
-    ) \
-  ) 
-else
-  $(foreach in_out,$(NUMS_IN_OUT), \
-    $(eval \
-      XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out))) = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out)))\
-    ) \
-  ) 
-endif
+$(foreach in_out,$(NUMS_IN_OUT), \
+  $(eval \
+    XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out))) = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out)))\
+  ) \
+)
 
 XMOS_MAKE_PATH ?= ../..
 -include $(XMOS_MAKE_PATH)/xcommon/module_xcommon/build/Makefile.common

--- a/tests/i2s_frame_master_external_clock_4b_test/src/main.xc
+++ b/tests/i2s_frame_master_external_clock_4b_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_frame_master_external_clock_4b_test/src/main.xc
+++ b/tests/i2s_frame_master_external_clock_4b_test/src/main.xc
@@ -27,17 +27,22 @@ in port  setup_resp_port = XS1_PORT_1M;
 #define DATA_BITS (32)
 #endif
 
+#define MAX_BCLK_FREQ_192 (192000 * 2 * DATA_BITS)
+#define MAX_BCLK_FREQ_176 (176400 * 2 * DATA_BITS)
+
+#define MCLK_FREQUENCY_192 (MAX_BCLK_FREQ_192 * 2) // 2 times the bclk required for the maximum sampling frequency
+#define MCLK_FREQUENCY_176 (MAX_BCLK_FREQ_176 * 2)
 
 #define NUM_MCLKS (2)
 #if NUM_OUT > 1 || NUM_IN > 1
 static const unsigned mclock_freq[NUM_MCLKS] = { // in0, out4 test fails timing check with the higher mclk
-        12288000,
-        11289600
+        MCLK_FREQUENCY_192/2,
+        MCLK_FREQUENCY_176/2
 };
 #else
 static const unsigned mclock_freq[NUM_MCLKS] = {
-        24576000,
-        22579200
+        MCLK_FREQUENCY_192,
+        MCLK_FREQUENCY_176
 };
 #endif
 

--- a/tests/i2s_frame_master_external_clock_4b_test/src/main.xc
+++ b/tests/i2s_frame_master_external_clock_4b_test/src/main.xc
@@ -21,42 +21,24 @@ out port setup_strobe_port = XS1_PORT_1L;
 out port setup_data_port = XS1_PORT_16A;
 in port  setup_resp_port = XS1_PORT_1M;
 
-#define MAX_RATIO (4)
-
 #define MAX_CHANNELS (8)
-
-#define MAX_NUM_RESTARTS (4)
 
 #ifndef DATA_BITS
 #define DATA_BITS (32)
 #endif
 
 
-
-#if defined(SMOKE)
+#define NUM_MCLKS (2)
 #if NUM_OUT > 1 || NUM_IN > 1
-#define NUM_MCLKS (1)
-static const unsigned mclock_freq[NUM_MCLKS] = {
+static const unsigned mclock_freq[NUM_MCLKS] = { // in0, out4 test fails timing check with the higher mclk
         12288000,
+        11289600
 };
 #else
-#define NUM_MCLKS (1)
 static const unsigned mclock_freq[NUM_MCLKS] = {
         24576000,
+        22579200
 };
-#endif
-#else
-#if NUM_OUT > 1 || NUM_IN > 1
-#define NUM_MCLKS (1)
-static const unsigned mclock_freq[NUM_MCLKS] = {
-        12288000,
-};
-#else
-#define NUM_MCLKS (1)
-static const unsigned mclock_freq[NUM_MCLKS] = {
-        24576000,
-};
-#endif
 #endif
 
 int32_t tx_data[MAX_CHANNELS][8] = {
@@ -128,7 +110,6 @@ void app(server interface i2s_frame_callback_if i2s_i){
     unsigned tx_data_counter[MAX_CHANNELS] = {0};
 
     int first_time = 1;
-    uint32_t num_restarts = 0;
 
     while(1){
         select {
@@ -159,7 +140,6 @@ void app(server interface i2s_frame_callback_if i2s_i){
             if (frames_sent == 4)
             {
               restart = I2S_RESTART;
-              num_restarts += 1;
             }
             else
               restart = I2S_NO_RESTART;
@@ -169,7 +149,7 @@ void app(server interface i2s_frame_callback_if i2s_i){
             //bclock frequency is not changed in restart when using i2s_frame_master_external_clock.
             //The clock needs to be set externally once, before starting i2s_frame_master_external_clock.
 
-            if(!first_time) 
+            if(!first_time)
             {
                  unsigned x=request_response(setup_strobe_port, setup_resp_port);
                  error |= x;
@@ -180,12 +160,13 @@ void app(server interface i2s_frame_callback_if i2s_i){
                  }
                  else
                  {
+                    mclock_freq_index += 1;
                     current_mode = I2S_MODE_I2S;
+                    if(mclock_freq_index == NUM_MCLKS)
+                    {
+                        _Exit(1);
+                    }
                  }
-                if(num_restarts >= MAX_NUM_RESTARTS)
-                {
-                    _Exit(1);
-                }
             }
 
             frames_sent = 0;
@@ -228,14 +209,14 @@ void setup_bclock()
     broadcast(mclock_freq[mclock_freq_index],
             mclk_bclk_ratio, NUM_IN, NUM_OUT,
             current_mode == I2S_MODE_I2S, DATA_BITS);
-    
+
     configure_clock_src_divide(bclk, p_mclk, mclk_bclk_ratio >> 1);
 }
 
 
 int main(){
     interface i2s_frame_callback_if i2s_i;
-    
+
     par {
     {
         setup_bclock();

--- a/tests/i2s_frame_master_external_clock_test/src/main.xc
+++ b/tests/i2s_frame_master_external_clock_test/src/main.xc
@@ -29,20 +29,17 @@ in port  setup_resp_port = XS1_PORT_1M;
 #endif
 
 
+#define MAX_BCLK_FREQ_192 (192000 * 2 * DATA_BITS)
+#define MAX_BCLK_FREQ_176 (176400 * 2 * DATA_BITS)
+
+#define MCLK_FREQUENCY_192 (MAX_BCLK_FREQ_192 * 2) // 2 times the bclk required for the maximum sampling frequency
+#define MCLK_FREQUENCY_176 (MAX_BCLK_FREQ_176 * 2)
 
 #define NUM_MCLKS (2)
-#if (DATA_BITS != 24)
 static const unsigned mclock_freq[NUM_MCLKS] = {
-        24576000,
-        22579200
+        MCLK_FREQUENCY_192,
+        MCLK_FREQUENCY_176
 };
-#else
-static const unsigned mclock_freq[NUM_MCLKS] = {
-        18432000, // Set an Mclk such that max sampling freq is 192000 for 24 bits for mclk_bclk_ratio=2
-        16934400
-};
-#endif
-
 
 int32_t tx_data[MAX_CHANNELS][8] = {
         {  1,   2,   3,   4,   5,   6,   7,   8},
@@ -205,16 +202,8 @@ void setup_bclock()
     mclock_freq_index=0;
     ratio_log2 = 1;
     current_mode = I2S_MODE_I2S;
+    mclk_bclk_ratio = (1 << ratio_log2);
 
-    if (IS_POWER_OF_2(DATA_BITS))
-    {
-        unsigned base_ratio = 1 << (clz(DATA_BITS) - 26);
-        mclk_bclk_ratio = (base_ratio << ratio_log2);
-    }
-    else
-    {
-        mclk_bclk_ratio = (1 << ratio_log2);
-    }
     broadcast(mclock_freq[mclock_freq_index],
             mclk_bclk_ratio, NUM_IN, NUM_OUT,
             current_mode == I2S_MODE_I2S, DATA_BITS);

--- a/tests/i2s_frame_master_external_clock_test/src/main.xc
+++ b/tests/i2s_frame_master_external_clock_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_frame_master_external_clock_test/src/main.xc
+++ b/tests/i2s_frame_master_external_clock_test/src/main.xc
@@ -21,11 +21,8 @@ out port setup_strobe_port = XS1_PORT_1L;
 out port setup_data_port = XS1_PORT_16A;
 in port  setup_resp_port = XS1_PORT_1M;
 
-#define MAX_RATIO (4)
 
 #define MAX_CHANNELS (8)
-
-#define MAX_NUM_RESTARTS (4)
 
 #ifndef DATA_BITS
 #define DATA_BITS (32)

--- a/tests/i2s_frame_master_test/Makefile
+++ b/tests/i2s_frame_master_test/Makefile
@@ -38,22 +38,22 @@ MCLK_FAMILY ?= 48
 
 ifeq ($(SMOKE), 1)
   $(foreach db,$(BITDEPTHS), \
-	$(foreach mclk,$(MCLK_FAMILY), \
-    $(foreach in_out,$(NUMS_IN_OUT), \
-      $(eval \
-        XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk)_smoke = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE -DMCLK_FAMILY=$(mclk)\
+    $(foreach mclk,$(MCLK_FAMILY), \
+      $(foreach in_out,$(NUMS_IN_OUT), \
+        $(eval \
+          XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk)_smoke = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE -DMCLK_FAMILY=$(mclk)\
+        ) \
       ) \
-    ) \
 	) \
   )
 else
   $(foreach db,$(BITDEPTHS), \
     $(foreach mclk,$(MCLK_FAMILY), \
-    $(foreach in_out,$(NUMS_IN_OUT), \
-      $(eval \
-        XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk) = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DMCLK_FAMILY=$(mclk)\
+      $(foreach in_out,$(NUMS_IN_OUT), \
+        $(eval \
+          XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk) = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DMCLK_FAMILY=$(mclk)\
+        ) \
       ) \
-    ) \
 	) \
   )
 endif

--- a/tests/i2s_frame_master_test/Makefile
+++ b/tests/i2s_frame_master_test/Makefile
@@ -18,7 +18,7 @@ endif
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to
 # the project name
-APP_NAME = 
+APP_NAME =
 
 # The USED_MODULES variable lists other module used by the application.
 USED_MODULES = lib_i2s
@@ -34,22 +34,27 @@ COMMON_FLAGS = -O3 -g -save-temps
 BITDEPTHS ?= 8 16 24 32
 NUMS_IN_OUT ?= 4;4 1;1 4;0 0;4
 SMOKE ?= 1
+MCLK_FAMILY ?= 48
 
 ifeq ($(SMOKE), 1)
   $(foreach db,$(BITDEPTHS), \
+	$(foreach mclk,$(MCLK_FAMILY), \
     $(foreach in_out,$(NUMS_IN_OUT), \
       $(eval \
-        XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_smoke = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE\
+        XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk)_smoke = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE -DMCLK_FAMILY=$(mclk)\
       ) \
     ) \
-  ) 
+	) \
+  )
 else
   $(foreach db,$(BITDEPTHS), \
+    $(foreach mclk,$(MCLK_FAMILY), \
     $(foreach in_out,$(NUMS_IN_OUT), \
       $(eval \
-        XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out))) = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out)))\
+        XCC_FLAGS_$(db)_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_$(mclk) = $(COMMON_FLAGS) -DDATA_BITS=$(db) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DMCLK_FAMILY=$(mclk)\
       ) \
     ) \
+	) \
   )
 endif
 

--- a/tests/i2s_frame_master_test/src/main.xc
+++ b/tests/i2s_frame_master_test/src/main.xc
@@ -319,7 +319,7 @@ int main()
     par
     {
         {
-        setup_bclk(); // For the very first iteration. For subsequent iterations, set in i2s_i.init()
+            setup_bclk(); // For the very first iteration. For subsequent iterations, set in i2s_i.init()
             par {
                 [[distribute]]
                     app(i2s_i);

--- a/tests/i2s_frame_master_test/src/main.xc
+++ b/tests/i2s_frame_master_test/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_frame_slave_4b_test/Makefile
+++ b/tests/i2s_frame_slave_4b_test/Makefile
@@ -29,7 +29,7 @@ USED_MODULES = lib_i2s
 # If the variable XCC_MAP_FLAGS is set it overrides the flags passed to
 # xcc for the final link (mapping) stage.
 
-COMMON_FLAGS = -O2 -g -save-temps
+COMMON_FLAGS = -O3 -g -save-temps
 
 NUMS_IN_OUT ?= 4;4 1;1 4;0 0;4
 SMOKE ?= 1
@@ -41,13 +41,13 @@ ifeq ($(SMOKE), 1)
       $(eval \
         XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_smoke = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE -DSLAVE_INVERT_BCLK\
       ) \
-    ) 
+    )
   else
     $(foreach in_out,$(NUMS_IN_OUT), \
       $(eval \
         XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out)))_smoke = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSMOKE\
       ) \
-    ) 
+    )
   endif
 else
   ifeq ($(INVERT), 1)
@@ -55,13 +55,13 @@ else
       $(eval \
         XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out))) = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out))) -DSLAVE_INVERT_BCLK\
       ) \
-    ) 
+    )
   else
     $(foreach in_out,$(NUMS_IN_OUT), \
       $(eval \
         XCC_FLAGS_$(word 1, $(subst ;, ,$(in_out)))_$(word 2, $(subst ;, ,$(in_out))) = $(COMMON_FLAGS) -DNUM_OUT=$(word 2, $(subst ;, ,$(in_out))) -DNUM_IN=$(word 1, $(subst ;, ,$(in_out)))\
       ) \
-    ) 
+    )
   endif
 endif
 

--- a/tests/i2s_frame_slave_4b_test/src/i2s_frame_slave_test.xc
+++ b/tests/i2s_frame_slave_4b_test/src/i2s_frame_slave_test.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_frame_slave_4b_test/src/i2s_frame_slave_test.xc
+++ b/tests/i2s_frame_slave_4b_test/src/i2s_frame_slave_test.xc
@@ -34,7 +34,7 @@ in port  setup_resp_port = XS1_PORT_1M;
 #define DATA_BITS (32)
 #endif
 
-// Only 1 in, 1 out pass timing for 192KHz sampling freq, all the other channel count combinations fail timing for 192 KHz(and 176.4)
+// Only 1 channel in, 1 channel out pass timing for 192KHz sampling freq, all the other channel count combinations fail timing for 192 KHz(and 176.4)
 #if defined(SMOKE)
 #define NUM_LRCLKS_TO_CHECK 1
 #if NUM_IN == 1 && NUM_OUT == 1

--- a/tests/i2s_frame_slave_test/Makefile
+++ b/tests/i2s_frame_slave_test/Makefile
@@ -29,7 +29,7 @@ USED_MODULES = lib_i2s
 # If the variable XCC_MAP_FLAGS is set it overrides the flags passed to
 # xcc for the final link (mapping) stage.
 
-COMMON_FLAGS = -O2 -g -save-temps
+COMMON_FLAGS = -O3 -g -save-temps
 
 BITDEPTHS ?= 8 16 24 32
 NUMS_IN_OUT ?= 4;4 1;1 4;0 0;4

--- a/tests/i2s_frame_slave_test/src/i2s_frame_slave_test.xc
+++ b/tests/i2s_frame_slave_test/src/i2s_frame_slave_test.xc
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <i2s.h>

--- a/tests/i2s_frame_slave_test/src/i2s_frame_slave_test.xc
+++ b/tests/i2s_frame_slave_test/src/i2s_frame_slave_test.xc
@@ -26,17 +26,14 @@ in port  setup_resp_port = XS1_PORT_1M;
 #endif
 
 #if defined(SMOKE)
-#define NUM_BCLKS (1)
-#define NUM_BCLKS_TO_CHECK (1)
-static const unsigned bclk_freq_lut[NUM_BCLKS] = {
-  1228800
+#define NUM_LRCLKS_TO_CHECK 1
+static const unsigned lr_freq_lut[] = {
+  192000
 };
 #else
-#define NUM_BCLKS (10)
-#define NUM_BCLKS_TO_CHECK (3)
-static const unsigned bclk_freq_lut[NUM_BCLKS] = {
-  1228800, 614400, 384000, 192000, 44100,
-  22050, 96000, 176400, 88200, 48000, 24000, 352800
+#define NUM_LRCLKS_TO_CHECK 6
+static const unsigned lr_freq_lut[] = {
+  192000, 176400, 96000, 88200, 48000, 44100
 };
 #endif
 
@@ -100,7 +97,7 @@ static int request_response(
 [[distributable]]
 #pragma unsafe arrays
 void app(server interface i2s_frame_callback_if i2s_i){
-    unsigned bclk_freq_index = 0;
+    unsigned lr_freq_index = 0;
     unsigned frames_sent = 0;
     unsigned rx_data_counter[MAX_CHANNELS] = {0};
     unsigned tx_data_counter[MAX_CHANNELS] = {0};
@@ -155,15 +152,15 @@ void app(server interface i2s_frame_callback_if i2s_i){
                     printf("Error\n");
                 }
 
-                if (bclk_freq_index == NUM_BCLKS_TO_CHECK-1) {
+                if (lr_freq_index == NUM_LRCLKS_TO_CHECK-1) {
                     if (current_mode == I2S_MODE_I2S) {
                         current_mode = I2S_MODE_LEFT_JUSTIFIED;
-                        bclk_freq_index = 0;
+                        lr_freq_index = 0;
                     } else {
                         _Exit(1);
                     }
                 } else {
-                    bclk_freq_index++;
+                    lr_freq_index++;
                 }
             }
 
@@ -178,7 +175,8 @@ void app(server interface i2s_frame_callback_if i2s_i){
                 rx_data_counter[i] = 0;
             }
 
-            broadcast(bclk_freq_lut[bclk_freq_index],
+            unsigned bclk_freq = lr_freq_lut[lr_freq_index] * DATA_BITS * I2S_CHANS_PER_FRAME;
+            broadcast(bclk_freq,
                     NUM_IN, NUM_OUT, i2s_config.mode == I2S_MODE_I2S, DATA_BITS);
 
             break;
@@ -192,7 +190,7 @@ int main(){
 
     par {
       [[distribute]] app(i2s_i);
-      i2s_frame_slave(i2s_i, p_dout, NUM_OUT, p_din, NUM_IN, DATA_BITS, 
+      i2s_frame_slave(i2s_i, p_dout, NUM_OUT, p_din, NUM_IN, DATA_BITS,
                 p_bclk, p_lrclk, bclk);
       par(int i=0;i<7;i++){
         { set_core_fast_mode_on();

--- a/tests/i2s_slave_checker.py
+++ b/tests/i2s_slave_checker.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import Clock
 import Pyxsim as px

--- a/tests/i2s_slave_checker.py
+++ b/tests/i2s_slave_checker.py
@@ -5,7 +5,7 @@ import Pyxsim as px
 from functools import partial
 
 # We need to disable output buffering for this test to work on MacOS; this has
-# no effect on Linux systems. Let's redefine print once to avoid putting the 
+# no effect on Linux systems. Let's redefine print once to avoid putting the
 # same argument everywhere.
 print = partial(print, flush=True)
 
@@ -141,7 +141,7 @@ class I2SSlaveChecker(px.SimThread):
             # there is one frame lead in for the slave to sync to
             # The logic of this section is slightly convoluted, but essentially
             #     we are counting samples in the /whole/ LR period:
-            # 
+            #
             # - Set lr_counter to db + db/2 + (0 or 1 depending on I2S mode)
             # - lr_counter may exist in the range 0:(2*db - 1)
             # - If it is <db, output 0 on lr_clock
@@ -151,6 +151,10 @@ class I2SSlaveChecker(px.SimThread):
             #       the range 32 - 63, lr_clock outputs 1, else it outputs 0.
 
             time = float(xsi.get_time())
+
+            time = self.wait_until_ret(
+                time + (clock_half_period * 64)
+            )  # Add extra delay to ensure that the i2s_slave device sees the LRCLK transitions in the first for loop below
 
             lr_counter = data_bits + (data_bits // 2) + (is_i2s_justified)
             lr_count_max = (2 * data_bits) - 1

--- a/tests/test_basic_frame_master.py
+++ b/tests/test_basic_frame_master.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import I2SMasterChecker, Clock
 from pathlib import Path

--- a/tests/test_basic_frame_master.py
+++ b/tests/test_basic_frame_master.py
@@ -25,6 +25,9 @@ def test_i2s_basic_frame_master(capfd, request, nightly, bitdepth, num_in, num_o
     if (num_in in (0,1,2,3) or num_out in (0,1,2,3)) and not nightly:
         pytest.skip("Only test 4ch modes if not nightly")
 
+    if (bitdepth == 24 and mclk_fam == "mclk_fam_44"):
+        pytest.skip("24 bit only tested with frequencies for the 48KHz family") # TODO JIRA
+
     if mclk_fam == "mclk_fam_48":
         mclk_fam = 48
     else:
@@ -62,7 +65,7 @@ def test_i2s_basic_frame_master(capfd, request, nightly, bitdepth, num_in, num_o
     Pyxsim.run_on_simulator(
         binary,
         tester=tester,
-        #clean_before_build=True,
+        clean_before_build=True,
         simthreads=[clk, checker],
         build_env = {"BITDEPTHS":f"{bitdepth}", "NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel, "MCLK_FAMILY":f'{mclk_fam}'},
         simargs=[],

--- a/tests/test_basic_frame_master_4b.py
+++ b/tests/test_basic_frame_master_4b.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import I2SMasterChecker, Clock
 from pathlib import Path

--- a/tests/test_basic_frame_master_4b.py
+++ b/tests/test_basic_frame_master_4b.py
@@ -10,11 +10,17 @@ num_in_out_args = {"4ch_in,4ch_out": (4, 4),
                    "4ch_in,0ch_out": (4, 0),
                    "0ch_in,4ch_out": (0, 4)}
 
+mclk_family = ["mclk_fam_48", "mclk_fam_44"] # The base sampling rate needs to be configured differently for 48KHz vs 44.1KHz family
+
+@pytest.mark.parametrize("mclk_fam", mclk_family)
 @pytest.mark.parametrize(("num_in", "num_out"), num_in_out_args.values(), ids=num_in_out_args.keys())
-def test_i2s_basic_frame_master_4b(capfd, request, nightly, num_in, num_out):
-    testlevel = '0' if nightly else '1'
-    id_string = f"{num_in}_{num_out}"
-    id_string += "_smoke" if testlevel == '1' else ""
+def test_i2s_basic_frame_master_4b(capfd, request, nightly, num_in, num_out, mclk_fam):
+    if mclk_fam == "mclk_fam_48":
+        mclk_fam = 48
+    else:
+        mclk_fam = 44
+
+    id_string = f"{num_in}_{num_out}_{mclk_fam}"
 
     cwd = Path(request.fspath).parent
     binary = f'{cwd}/i2s_frame_master_4b_test/bin/{id_string}/i2s_frame_master_4b_test_{id_string}.xe'
@@ -45,7 +51,8 @@ def test_i2s_basic_frame_master_4b(capfd, request, nightly, num_in, num_out):
         binary,
         tester=tester,
         simthreads=[clk, checker],
-        build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+        clean_before_build=True,
+        build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "MCLK_FAMILY":f'{mclk_fam}'},
         simargs=[],
         capfd=capfd
     )

--- a/tests/test_basic_frame_master_external_clock.py
+++ b/tests/test_basic_frame_master_external_clock.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import I2SMasterChecker, Clock
 from pathlib import Path

--- a/tests/test_basic_frame_master_external_clock.py
+++ b/tests/test_basic_frame_master_external_clock.py
@@ -50,6 +50,7 @@ def test_i2s_basic_frame_master_external_clock(capfd, request, nightly, bitdepth
     Pyxsim.run_on_simulator(
         binary,
         tester=tester,
+        clean_before_build=True,
         simthreads=[clk, checker],
         build_env = {"BITDEPTHS":f"{bitdepth}", "NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
         simargs=[],

--- a/tests/test_basic_frame_master_external_clock_4b.py
+++ b/tests/test_basic_frame_master_external_clock_4b.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import I2SMasterChecker, Clock
 from pathlib import Path

--- a/tests/test_basic_frame_master_external_clock_4b.py
+++ b/tests/test_basic_frame_master_external_clock_4b.py
@@ -12,9 +12,7 @@ num_in_out_args = {"4ch_in,4ch_out": (4, 4),
 
 @pytest.mark.parametrize(("num_in", "num_out"), num_in_out_args.values(), ids=num_in_out_args.keys())
 def test_i2s_basic_frame_master_external_clock_4b(capfd, request, nightly, num_in, num_out):
-    testlevel = '0' if nightly else '1'
     id_string = f"{num_in}_{num_out}"
-    id_string += "_smoke" if testlevel == '1' else ""
 
     cwd = Path(request.fspath).parent
     binary = f'{cwd}/i2s_frame_master_external_clock_4b_test/bin/{id_string}/i2s_frame_master_external_clock_4b_test_{id_string}.xe'
@@ -44,8 +42,9 @@ def test_i2s_basic_frame_master_external_clock_4b(capfd, request, nightly, num_i
     Pyxsim.run_on_simulator(
         binary,
         tester=tester,
+        clean_before_build=True,
         simthreads=[clk, checker],
-        build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+        build_env = {"NUMS_IN_OUT":f'{num_in};{num_out}'},
         simargs=[],
         capfd=capfd
     )

--- a/tests/test_basic_frame_slave.py
+++ b/tests/test_basic_frame_slave.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import Clock
 from i2s_slave_checker import I2SSlaveChecker

--- a/tests/test_basic_frame_slave.py
+++ b/tests/test_basic_frame_slave.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import Pyxsim
 import pytest
 
+DEBUG = False
+
 num_in_out_args = {"4ch_in,4ch_out": (4, 4),
+                   "2ch_in,2ch_out": (2, 2),
                    "1ch_in,1ch_out": (1, 1),
                    "4ch_in,0ch_out": (4, 0),
                    "0ch_in,4ch_out": (0, 4)}
@@ -46,11 +49,28 @@ def test_i2s_basic_frame_slave(capfd, request, nightly, bitdepth, num_in, num_ou
         ignore=["CONFIG:.*"]
     )
 
-    Pyxsim.run_on_simulator(
-        binary,
-        tester=tester,
-        simthreads=[clk, checker],
-        build_env = {"BITDEPTHS":f"{bitdepth}", "NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
-        simargs=[],
-        capfd=capfd
-    )
+    if DEBUG:
+        Pyxsim.run_on_simulator(
+            binary,
+            tester=tester,
+            simthreads=[clk, checker],
+            build_env = {"BITDEPTHS":f"{bitdepth}", "NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+            #clean_before_build=True,
+            simargs=[
+                "--vcd-tracing",
+                f"-o i2s_trace_{num_in}_{num_out}.vcd -tile tile[0] -cycles -ports -ports-detailed -cores -instructions",
+                "--trace-to",
+                f"i2s_trace_{num_in}_{num_out}.txt",
+            ],
+            capfd=capfd
+        )
+    else:
+        Pyxsim.run_on_simulator(
+            binary,
+            tester=tester,
+            simthreads=[clk, checker],
+            #clean_before_build=True,
+            build_env = {"BITDEPTHS":f"{bitdepth}", "NUMS_IN_OUT":f'{num_in};{num_out}', "SMOKE":testlevel},
+            simargs=[],
+            capfd=capfd
+        )

--- a/tests/test_basic_frame_slave_4b.py
+++ b/tests/test_basic_frame_slave_4b.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 XMOS LIMITED.
+# Copyright 2015-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from i2s_master_checker import Clock
 from i2s_slave_checker import I2SSlaveChecker

--- a/tests/test_basic_frame_slave_4b.py
+++ b/tests/test_basic_frame_slave_4b.py
@@ -7,6 +7,7 @@ import Pyxsim
 import pytest
 
 num_in_out_args = {"4ch_in,4ch_out": (4, 4),
+                   "2ch_in,2ch_out": (2, 2),
                    "1ch_in,1ch_out": (1, 1),
                    "4ch_in,0ch_out": (4, 0),
                    "0ch_in,4ch_out": (0, 4)}


### PR DESCRIPTION
https://xmosjira.atlassian.net/browse/AP-370

Fixed the following I2S tests to test the configurations they claim to test. Summary of changes below:

- test_basic_frame_slave - Ensure that we test with bclks corresponding to sampling frequencies from 192KHz - 44.1KHz

- test_i2s_frame_slave_4b - Same as above, except 192KHz sampling freq is only tested for 1in 1out case, the other channel combinations test up to 96KHz since they don't meet timing for 192KHz

- test_i2s_frame_master - This test has a lot of changes.
Fixed the base sampling rate to be 6KHz for the 48-192KHz family and 11.025KHz for the 44.1-176.4 sampling rate family.
Use mclks that are integer multiples of the the bclk for all sampling rates and data widths.
Change the code in i2s_i.init() to make sure that all the sampling rates do get tested.

- test_i2s_frame_master_4b - Same as test_i2s_frame_master, except that the 192KHz and 176.4KHz SR are tested only for the 1ch in 1ch out combination. All other channel combinations test upto a maximum of 96KHz, 88.1KHz and violate timing for 192,176.4KHz.

- test_i2s_frame_master_external -  Use mclks that are integer multiples of the the bclk for all data widths. Only sampling rates of 192 and 176.4KHz are tested (mclk_bclk_ratio = 2).

- test_i2s_frame_master_external_4b - Same as test_i2s_frame_master_external except only the 1ch in 1ch out case is tested for 192, 176.4KHz sampling rates, while the other channel combinations are tested for 96, 88.1KHz sampling rates.
