### PR TITLE
Update JSL and Python

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.31.0') _
+@Library('xmos_jenkins_shared_library@v0.32.0') _
 
 getApproval()
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 XMOS LIMITED.
+# Copyright 2020-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,6 +14,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'flake8~=7.0',
+        'pytest~=8.2',
+        'pytest-xdist~=3.6',
     ],
     dependency_links=[
     ],

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     name='lib_i2s',
     packages=setuptools.find_packages(),
     install_requires=[
-        'flake8~=3.8',
+        'flake8~=7.0',
     ],
     dependency_links=[
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# python_version 3.7.6
+# python_version 3.12
 #
 # The parse_version_from_requirements() function in the installPipfile.groovy
 # file of the Jenkins Shared Library uses the python_version comment to set

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
 
-flake8==3.8.3
+flake8==7.0.0
 # Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
 importlib-metadata==4.13.0
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,6 @@
 # same modules should appear in the setup.py list as given below.
 
 flake8==7.0.0
-# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
-importlib-metadata==4.13.0
 pytest
 pytest-xdist
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,8 @@
 # same modules should appear in the setup.py list as given below.
 
 flake8==7.0.0
-pytest
-pytest-xdist
+pytest==8.2.2
+pytest-xdist==3.6.1
 
 # Development dependencies
 #


### PR DESCRIPTION
Part of LSM-79
Fixes get-pip.py compatibility issue with Python 3.7